### PR TITLE
Create static jewelry storefront

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -1,0 +1,889 @@
+:root {
+  --bg: #0C0C0C;
+  --surface: #121212;
+  --text: #FFFFFF;
+  --muted: #808080;
+  --gold: #D4AF37;
+  --radius: 12px;
+  --shadow: 0 20px 40px rgba(0, 0, 0, 0.35);
+  --font: 'Inter', 'Segoe UI', Roboto, 'Noto Sans', sans-serif;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html {
+  scroll-behavior: smooth;
+}
+
+body {
+  margin: 0;
+  font-family: var(--font);
+  background: var(--bg);
+  color: var(--text);
+  line-height: 1.6;
+}
+
+body.is-locked {
+  overflow: hidden;
+}
+
+img {
+  max-width: 100%;
+  display: block;
+  border-radius: var(--radius);
+}
+
+a {
+  color: inherit;
+  text-decoration: none;
+}
+
+a:hover,
+a:focus-visible {
+  color: var(--gold);
+}
+
+.skip-link {
+  position: absolute;
+  left: -999px;
+  top: 1rem;
+  background: var(--gold);
+  color: var(--bg);
+  padding: 0.75rem 1rem;
+  border-radius: var(--radius);
+  font-weight: 600;
+  z-index: 999;
+}
+
+.skip-link:focus {
+  left: 1rem;
+}
+
+.header {
+  position: sticky;
+  top: 0;
+  width: 100%;
+  z-index: 100;
+  background: rgba(12, 12, 12, 0.95);
+  backdrop-filter: blur(12px);
+  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.header__inner {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 0.75rem 1.5rem;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.header__nav {
+  position: relative;
+}
+
+.header__toggle {
+  background: transparent;
+  border: 1px solid rgba(255, 255, 255, 0.3);
+  border-radius: var(--radius);
+  padding: 0.5rem 0.75rem;
+  color: var(--text);
+  font-size: 1rem;
+  display: inline-flex;
+  align-items: center;
+  cursor: pointer;
+}
+
+.header__menu {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  position: absolute;
+  top: calc(100% + 0.5rem);
+  right: 0;
+  background: var(--surface);
+  border-radius: var(--radius);
+  box-shadow: var(--shadow);
+  padding: 1rem;
+  display: none;
+  gap: 0.5rem;
+  min-width: 200px;
+}
+
+.header__menu a,
+.header__menu button {
+  display: block;
+  width: 100%;
+  text-align: left;
+  padding: 0.5rem 0.75rem;
+  border-radius: var(--radius);
+  border: none;
+  background: transparent;
+  color: var(--text);
+  font-size: 0.95rem;
+  cursor: pointer;
+}
+
+.header__menu a:hover,
+.header__menu a:focus-visible,
+.header__menu button:hover,
+.header__menu button:focus-visible {
+  background: rgba(212, 175, 55, 0.15);
+  color: var(--gold);
+}
+
+.header__cart-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+}
+
+.header__cart-count {
+  background: var(--gold);
+  color: var(--bg);
+  font-size: 0.75rem;
+  font-weight: 700;
+  padding: 0 0.4rem;
+  border-radius: 999px;
+}
+
+.hero {
+  max-width: 1200px;
+  margin: 6.5rem auto 3rem;
+  padding: 0 1.5rem;
+  display: grid;
+  gap: 2rem;
+}
+
+.hero__content h1 {
+  font-size: clamp(2.5rem, 5vw, 3.75rem);
+  margin-bottom: 1rem;
+}
+
+.hero__content p {
+  color: var(--muted);
+  margin-bottom: 2rem;
+}
+
+.hero__media img {
+  width: 100%;
+  height: auto;
+}
+
+.btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.85rem 1.5rem;
+  border-radius: var(--radius);
+  font-weight: 600;
+  border: none;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.btn--primary {
+  background: var(--gold);
+  color: var(--bg);
+  box-shadow: 0 12px 24px rgba(212, 175, 55, 0.35);
+}
+
+.btn--primary:hover,
+.btn--primary:focus-visible {
+  transform: translateY(-2px);
+  box-shadow: 0 16px 28px rgba(212, 175, 55, 0.4);
+}
+
+.btn--outline {
+  background: transparent;
+  border: 1px solid var(--gold);
+  color: var(--gold);
+}
+
+.btn--outline:hover,
+.btn--outline:focus-visible {
+  background: rgba(212, 175, 55, 0.15);
+}
+
+.section-header {
+  max-width: 1200px;
+  margin: 0 auto 2rem;
+  padding: 0 1.5rem;
+}
+
+.section-header h2 {
+  font-size: clamp(2rem, 4vw, 2.5rem);
+  margin-bottom: 0.5rem;
+}
+
+.section-header p {
+  color: var(--muted);
+  margin: 0;
+}
+
+.catalogo {
+  padding: 2rem 0 4rem;
+}
+
+.catalogo__toolbar {
+  max-width: 1200px;
+  margin: 0 auto 2rem;
+  padding: 0 1.5rem;
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+}
+
+.field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+  font-size: 0.9rem;
+}
+
+.field input,
+.field select {
+  background: var(--surface);
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: var(--radius);
+  padding: 0.6rem 0.75rem;
+  color: var(--text);
+  font-size: 0.95rem;
+}
+
+.field input:focus,
+.field select:focus {
+  outline: 2px solid rgba(212, 175, 55, 0.4);
+  border-color: rgba(212, 175, 55, 0.8);
+}
+
+.catalogo__grid {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 0 1.5rem;
+  display: grid;
+  gap: 1.5rem;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+}
+
+.catalogo__empty {
+  grid-column: 1 / -1;
+  background: rgba(255, 255, 255, 0.02);
+  padding: 2rem;
+  border-radius: var(--radius);
+  text-align: center;
+  color: var(--muted);
+}
+
+.card {
+  background: var(--surface);
+  padding: 1.25rem;
+  border-radius: var(--radius);
+  box-shadow: var(--shadow);
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.card:hover {
+  transform: translateY(-6px);
+  box-shadow: 0 24px 36px rgba(0, 0, 0, 0.45);
+}
+
+.card__img {
+  position: relative;
+  width: 100%;
+  padding-top: 100%;
+  border-radius: var(--radius);
+  overflow: hidden;
+  background: rgba(255, 255, 255, 0.02);
+}
+
+.card__img img {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.card__badge {
+  position: absolute;
+  top: 0.75rem;
+  left: 0.75rem;
+  background: var(--gold);
+  color: var(--bg);
+  padding: 0.3rem 0.65rem;
+  border-radius: 999px;
+  font-size: 0.75rem;
+  font-weight: 700;
+}
+
+.card__title {
+  font-size: 1.1rem;
+  margin: 0;
+}
+
+.card__price {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-weight: 600;
+}
+
+.card__price del {
+  color: var(--muted);
+}
+
+.card__rating {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  color: var(--gold);
+}
+
+.card__actions {
+  display: flex;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
+.card__actions button {
+  flex: 1;
+}
+
+.about,
+.testimonios,
+.faq,
+.checkout,
+.contacto {
+  padding: 4rem 0;
+}
+
+.about__grid,
+.testimonios__grid {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 0 1.5rem;
+  display: grid;
+  gap: 1.5rem;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+}
+
+.about__card,
+.testimonial,
+.faq__items details {
+  background: var(--surface);
+  padding: 1.5rem;
+  border-radius: var(--radius);
+  box-shadow: var(--shadow);
+}
+
+.testimonial blockquote {
+  margin: 0 0 1rem;
+  font-style: italic;
+  color: rgba(255, 255, 255, 0.85);
+}
+
+.faq__items {
+  max-width: 900px;
+  margin: 0 auto;
+  padding: 0 1.5rem;
+  display: grid;
+  gap: 1rem;
+}
+
+.faq__items summary {
+  cursor: pointer;
+  font-weight: 600;
+}
+
+.checkout__layout {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 0 1.5rem;
+  display: grid;
+  gap: 2rem;
+}
+
+.checkout__form,
+.checkout__summary {
+  background: var(--surface);
+  padding: 1.5rem;
+  border-radius: var(--radius);
+  box-shadow: var(--shadow);
+}
+
+.form-group {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+  margin-bottom: 1rem;
+}
+
+.form-group input,
+.form-group textarea {
+  background: rgba(255, 255, 255, 0.02);
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: var(--radius);
+  padding: 0.65rem 0.75rem;
+  color: var(--text);
+  font-size: 0.95rem;
+}
+
+.form-group input.invalid,
+.form-group textarea.invalid {
+  border-color: rgba(255, 99, 99, 0.8);
+}
+
+.form-group input:focus,
+.form-group textarea:focus {
+  outline: 2px solid rgba(212, 175, 55, 0.4);
+  border-color: rgba(212, 175, 55, 0.8);
+}
+
+.form-helper {
+  font-size: 0.85rem;
+  color: var(--muted);
+}
+
+.form-feedback {
+  margin-top: 1rem;
+  font-weight: 600;
+}
+
+.summary-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.95rem;
+}
+
+.summary-table th,
+.summary-table td {
+  padding: 0.75rem 0.5rem;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.summary-table thead th {
+  text-align: left;
+  color: var(--muted);
+  font-weight: 500;
+}
+
+.summary-table tfoot td {
+  font-weight: 600;
+}
+
+.checkout__success {
+  margin-top: 2rem;
+  padding: 1.5rem;
+  border-radius: var(--radius);
+  background: rgba(212, 175, 55, 0.08);
+  border: 1px solid rgba(212, 175, 55, 0.2);
+}
+
+.contacto__layout {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 0 1.5rem;
+  display: grid;
+  gap: 2rem;
+}
+
+.contacto__info p {
+  margin: 0 0 1rem;
+}
+
+.footer {
+  border-top: 1px solid rgba(255, 255, 255, 0.1);
+  padding: 2rem 1.5rem;
+  background: #050505;
+}
+
+.footer__inner {
+  max-width: 1200px;
+  margin: 0 auto;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  align-items: flex-start;
+}
+
+.footer__social {
+  display: flex;
+  gap: 1rem;
+}
+
+.modal[hidden],
+.cart[hidden] {
+  display: none;
+}
+
+.modal {
+  position: fixed;
+  inset: 0;
+  display: grid;
+  place-items: center;
+  z-index: 200;
+}
+
+.modal__overlay {
+  position: absolute;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.6);
+}
+
+.modal__content {
+  position: relative;
+  background: var(--surface);
+  border-radius: var(--radius);
+  box-shadow: var(--shadow);
+  padding: 2rem;
+  max-width: 960px;
+  width: min(90vw, 960px);
+  display: grid;
+  gap: 2rem;
+}
+
+.modal__gallery {
+  position: relative;
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  align-items: center;
+  gap: 1rem;
+}
+
+.modal__gallery img {
+  width: 100%;
+  max-height: 420px;
+  object-fit: cover;
+}
+
+.modal__nav {
+  background: rgba(255, 255, 255, 0.05);
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  color: var(--text);
+  border-radius: var(--radius);
+  width: 3rem;
+  height: 3rem;
+  cursor: pointer;
+}
+
+.modal__close {
+  position: absolute;
+  top: 1rem;
+  right: 1rem;
+  background: transparent;
+  border: none;
+  color: var(--text);
+  font-size: 2rem;
+  cursor: pointer;
+}
+
+.modal__details {
+  display: grid;
+  gap: 1rem;
+}
+
+.modal__specs {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: grid;
+  gap: 0.35rem;
+  color: var(--muted);
+}
+
+.modal__price {
+  font-size: 1.5rem;
+  font-weight: 700;
+  display: flex;
+  gap: 0.75rem;
+  align-items: center;
+}
+
+.modal__price del {
+  font-size: 1rem;
+  color: var(--muted);
+}
+
+.quantity-selector {
+  display: inline-flex;
+  align-items: center;
+  border-radius: var(--radius);
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  overflow: hidden;
+}
+
+.quantity-selector button {
+  background: transparent;
+  border: none;
+  color: var(--text);
+  width: 2.5rem;
+  height: 2.5rem;
+  cursor: pointer;
+}
+
+.quantity-selector input {
+  width: 3rem;
+  background: transparent;
+  border: none;
+  text-align: center;
+  color: var(--text);
+}
+
+.cart {
+  position: fixed;
+  inset: 0;
+  display: grid;
+  grid-template-columns: 1fr;
+  z-index: 190;
+}
+
+.cart__overlay {
+  background: rgba(0, 0, 0, 0.5);
+}
+
+.cart__overlay,
+.cart__content {
+  height: 100%;
+}
+
+.cart__content {
+  position: absolute;
+  top: 0;
+  right: 0;
+  width: min(420px, 100%);
+  background: var(--surface);
+  display: flex;
+  flex-direction: column;
+  box-shadow: -10px 0 30px rgba(0, 0, 0, 0.45);
+}
+
+.cart__header,
+.cart__footer {
+  padding: 1.5rem;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.cart__footer {
+  border-bottom: none;
+  border-top: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.cart__body {
+  flex: 1;
+  overflow-y: auto;
+  padding: 1.5rem;
+  display: grid;
+  gap: 1rem;
+}
+
+.cart-item {
+  display: grid;
+  grid-template-columns: 72px 1fr;
+  gap: 1rem;
+  align-items: center;
+}
+
+.cart-item__thumb {
+  width: 72px;
+  height: 72px;
+  border-radius: var(--radius);
+  overflow: hidden;
+}
+
+.cart-item__info {
+  display: grid;
+  gap: 0.35rem;
+}
+
+.cart-item__title {
+  font-size: 1rem;
+  font-weight: 600;
+}
+
+.cart-item__controls {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.cart-item__controls input {
+  width: 3rem;
+  background: rgba(255, 255, 255, 0.05);
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: var(--radius);
+  text-align: center;
+  color: var(--text);
+  padding: 0.3rem;
+}
+
+.cart-item__controls button {
+  background: transparent;
+  border: 1px solid rgba(255, 255, 255, 0.15);
+  color: var(--text);
+  border-radius: var(--radius);
+  width: 2.25rem;
+  height: 2.25rem;
+  cursor: pointer;
+}
+
+.cart-item__price {
+  font-weight: 600;
+}
+
+.badge {
+  display: inline-block;
+  margin-left: 0.25rem;
+  padding: 0.15rem 0.4rem;
+  border-radius: 999px;
+  background: rgba(212, 175, 55, 0.2);
+  color: var(--gold);
+  font-size: 0.7rem;
+  text-transform: uppercase;
+}
+
+.cart__summary {
+  display: grid;
+  gap: 0.75rem;
+  margin-bottom: 1.5rem;
+}
+
+.cart__summary div {
+  display: flex;
+  justify-content: space-between;
+  color: rgba(255, 255, 255, 0.85);
+}
+
+.cart__total {
+  font-size: 1.1rem;
+  font-weight: 700;
+}
+
+.whatsapp {
+  position: fixed;
+  right: 1.5rem;
+  bottom: 1.5rem;
+  background: var(--gold);
+  color: var(--bg);
+  padding: 0.75rem 1rem;
+  border-radius: 999px;
+  font-weight: 600;
+  box-shadow: 0 16px 32px rgba(212, 175, 55, 0.45);
+  display: inline-flex;
+  align-items: center;
+}
+
+.whatsapp:hover,
+.whatsapp:focus-visible {
+  transform: translateY(-3px);
+}
+
+@media (min-width: 768px) {
+  .header__menu {
+    display: flex !important;
+    position: static;
+    flex-direction: row;
+    background: transparent;
+    box-shadow: none;
+    padding: 0;
+    gap: 1rem;
+  }
+
+  .header__toggle {
+    display: none;
+  }
+
+  .header__menu a,
+  .header__menu button {
+    width: auto;
+    padding: 0.5rem 0.75rem;
+  }
+
+  .hero {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    align-items: center;
+  }
+
+  .checkout__layout {
+    grid-template-columns: 1.1fr 0.9fr;
+  }
+
+  .contacto__layout {
+    grid-template-columns: 1fr 1fr;
+    align-items: start;
+  }
+
+  .modal__content {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .modal__gallery {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (min-width: 1024px) {
+  .hero {
+    margin-top: 7.5rem;
+  }
+}
+
+@media (max-width: 767px) {
+  .header__menu[aria-expanded="true"] {
+    display: grid;
+  }
+}
+
+@media print {
+  body {
+    background: #ffffff;
+    color: #000000;
+    font-size: 12pt;
+  }
+
+  header,
+  .hero,
+  .catalogo,
+  .about,
+  .testimonios,
+  .faq,
+  .contacto,
+  .footer,
+  .cart,
+  .whatsapp {
+    display: none !important;
+  }
+
+  .checkout {
+    padding: 0;
+  }
+
+  .checkout__layout {
+    display: block;
+  }
+
+  .checkout__form {
+    display: none;
+  }
+
+  .checkout__summary {
+    box-shadow: none;
+    border: 1px solid #000;
+    color: #000;
+  }
+
+  .summary-table {
+    color: #000;
+  }
+
+  .summary-table th,
+  .summary-table td {
+    border-color: #000;
+  }
+}

--- a/assets/img/hero.jpg
+++ b/assets/img/hero.jpg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1600 900">
+  <defs>
+    <linearGradient id="grad" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#0C0C0C" />
+      <stop offset="100%" stop-color="#1f1f1f" />
+    </linearGradient>
+  </defs>
+  <rect width="1600" height="900" fill="url(#grad)" />
+  <text x="50%" y="50%" fill="#D4AF37" font-family="'Segoe UI', sans-serif" font-size="120" dominant-baseline="middle" text-anchor="middle">JF Joyas</text>
+  <text x="50%" y="60%" fill="#ffffff" font-family="'Segoe UI', sans-serif" font-size="48" dominant-baseline="middle" text-anchor="middle">Elegancia que perdura</text>
+</svg>

--- a/assets/img/logo.svg
+++ b/assets/img/logo.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 120 32">
+  <rect width="120" height="32" rx="16" fill="#0C0C0C" stroke="#D4AF37" stroke-width="2" />
+  <text x="50%" y="50%" fill="#D4AF37" font-family="'Segoe UI', sans-serif" font-size="16" font-weight="600" dominant-baseline="middle" text-anchor="middle">JF Joyas</text>
+</svg>

--- a/assets/img/products/product-1.jpg
+++ b/assets/img/products/product-1.jpg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 600 600">
+  <defs>
+    <linearGradient id="grad${i}" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#0C0C0C" />
+      <stop offset="100%" stop-color="#1a1a1a" />
+    </linearGradient>
+  </defs>
+  <rect width="600" height="600" rx="32" fill="url(#grad${i})" stroke="#D4AF37" stroke-width="4" />
+  <text x="50%" y="50%" fill="#D4AF37" font-family="'Segoe UI', sans-serif" font-size="48" font-weight="600" dominant-baseline="middle" text-anchor="middle">JF ${i}</text>
+</svg>

--- a/assets/img/products/product-2.jpg
+++ b/assets/img/products/product-2.jpg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 600 600">
+  <defs>
+    <linearGradient id="grad${i}" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#0C0C0C" />
+      <stop offset="100%" stop-color="#1a1a1a" />
+    </linearGradient>
+  </defs>
+  <rect width="600" height="600" rx="32" fill="url(#grad${i})" stroke="#D4AF37" stroke-width="4" />
+  <text x="50%" y="50%" fill="#D4AF37" font-family="'Segoe UI', sans-serif" font-size="48" font-weight="600" dominant-baseline="middle" text-anchor="middle">JF ${i}</text>
+</svg>

--- a/assets/img/products/product-3.jpg
+++ b/assets/img/products/product-3.jpg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 600 600">
+  <defs>
+    <linearGradient id="grad${i}" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#0C0C0C" />
+      <stop offset="100%" stop-color="#1a1a1a" />
+    </linearGradient>
+  </defs>
+  <rect width="600" height="600" rx="32" fill="url(#grad${i})" stroke="#D4AF37" stroke-width="4" />
+  <text x="50%" y="50%" fill="#D4AF37" font-family="'Segoe UI', sans-serif" font-size="48" font-weight="600" dominant-baseline="middle" text-anchor="middle">JF ${i}</text>
+</svg>

--- a/assets/img/products/product-4.jpg
+++ b/assets/img/products/product-4.jpg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 600 600">
+  <defs>
+    <linearGradient id="grad${i}" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#0C0C0C" />
+      <stop offset="100%" stop-color="#1a1a1a" />
+    </linearGradient>
+  </defs>
+  <rect width="600" height="600" rx="32" fill="url(#grad${i})" stroke="#D4AF37" stroke-width="4" />
+  <text x="50%" y="50%" fill="#D4AF37" font-family="'Segoe UI', sans-serif" font-size="48" font-weight="600" dominant-baseline="middle" text-anchor="middle">JF ${i}</text>
+</svg>

--- a/assets/img/products/product-5.jpg
+++ b/assets/img/products/product-5.jpg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 600 600">
+  <defs>
+    <linearGradient id="grad${i}" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#0C0C0C" />
+      <stop offset="100%" stop-color="#1a1a1a" />
+    </linearGradient>
+  </defs>
+  <rect width="600" height="600" rx="32" fill="url(#grad${i})" stroke="#D4AF37" stroke-width="4" />
+  <text x="50%" y="50%" fill="#D4AF37" font-family="'Segoe UI', sans-serif" font-size="48" font-weight="600" dominant-baseline="middle" text-anchor="middle">JF ${i}</text>
+</svg>

--- a/assets/img/products/product-6.jpg
+++ b/assets/img/products/product-6.jpg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 600 600">
+  <defs>
+    <linearGradient id="grad${i}" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#0C0C0C" />
+      <stop offset="100%" stop-color="#1a1a1a" />
+    </linearGradient>
+  </defs>
+  <rect width="600" height="600" rx="32" fill="url(#grad${i})" stroke="#D4AF37" stroke-width="4" />
+  <text x="50%" y="50%" fill="#D4AF37" font-family="'Segoe UI', sans-serif" font-size="48" font-weight="600" dominant-baseline="middle" text-anchor="middle">JF ${i}</text>
+</svg>

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -1,0 +1,668 @@
+(function () {
+  const { BRAND_NAME, TAGLINE, CURRENCY, PHONE_WHATSAPP, EMAIL } = BRAND_CONFIG;
+
+  const selectors = {
+    menu: document.getElementById('menu'),
+    toggle: document.querySelector('.header__toggle'),
+    cartButton: document.querySelector('[data-open-cart]'),
+    cartCount: document.querySelector('.header__cart-count'),
+    productGrid: document.getElementById('product-grid'),
+    search: document.getElementById('search'),
+    filterCategory: document.getElementById('filter-category'),
+    filterMaterial: document.getElementById('filter-material'),
+    filterPrice: document.getElementById('filter-price'),
+    sort: document.getElementById('sort'),
+    modal: document.getElementById('product-modal'),
+    modalImage: document.getElementById('modal-image'),
+    modalTitle: document.getElementById('product-modal-title'),
+    modalDescription: document.getElementById('modal-description'),
+    modalMaterial: document.getElementById('modal-material'),
+    modalSize: document.getElementById('modal-size'),
+    modalWeight: document.getElementById('modal-weight'),
+    modalStock: document.getElementById('modal-stock'),
+    modalPrice: document.getElementById('modal-price'),
+    modalQuantity: document.getElementById('modal-quantity'),
+    modalAdd: document.getElementById('modal-add'),
+    cartPanel: document.getElementById('cart-panel'),
+    cartItems: document.getElementById('cart-items'),
+    cartSubtotal: document.getElementById('cart-subtotal'),
+    cartDiscount: document.getElementById('cart-discount'),
+    cartTotal: document.getElementById('cart-total'),
+    goCheckout: document.getElementById('go-checkout'),
+    checkoutForm: document.getElementById('checkout-form'),
+    summaryBody: document.getElementById('summary-body'),
+    summarySubtotal: document.getElementById('summary-subtotal'),
+    summaryDiscount: document.getElementById('summary-discount'),
+    summaryTotal: document.getElementById('summary-total'),
+    checkoutSuccess: document.querySelector('.checkout__success'),
+    orderNumber: document.getElementById('order-number'),
+    printButton: document.getElementById('print-order'),
+    formFeedback: document.querySelector('.form-feedback'),
+    whatsapp: document.getElementById('whatsapp'),
+    year: document.getElementById('year')
+  };
+
+  const storageKey = 'jfjoyas-cart';
+  const currencyFormatter = new Intl.NumberFormat('es-EC', {
+    style: 'currency',
+    currency: CURRENCY
+  });
+
+  // Normaliza cantidades evitando valores NaN o fuera de rango.
+  function sanitizeQuantity(rawValue, maxStock = 99, enforceDefault = false) {
+    if (rawValue === '' || rawValue === null || rawValue === undefined) {
+      return enforceDefault ? 1 : null;
+    }
+    const parsed = parseInt(String(rawValue), 10);
+    if (!Number.isFinite(parsed)) {
+      return enforceDefault ? 1 : null;
+    }
+    const limitedStock = Math.min(maxStock ?? 99, 99);
+    return Math.min(Math.max(parsed, 1), limitedStock);
+  }
+
+  // Formateo consistente de moneda en USD.
+  function formatCurrency(value) {
+    return currencyFormatter.format(Number(value) || 0);
+  }
+
+  function loadCart() {
+    try {
+      const stored = localStorage.getItem(storageKey);
+      if (!stored) return [];
+      const parsed = JSON.parse(stored);
+      if (!Array.isArray(parsed)) return [];
+      return parsed.map((item) => ({
+        ...item,
+        cantidad: sanitizeQuantity(item.cantidad, item.stock, true)
+      }));
+    } catch (error) {
+      console.error('No se pudo cargar el carrito', error);
+      return [];
+    }
+  }
+
+  function saveCart() {
+    localStorage.setItem(storageKey, JSON.stringify(state.cart));
+  }
+
+  function getFinalPrice(product) {
+    return product.nuevo ? product.precio * 0.9 : product.precio;
+  }
+
+  const state = {
+    products: PRODUCTS.slice(),
+    filteredProducts: PRODUCTS.slice(),
+    search: '',
+    filters: {
+      category: 'all',
+      material: 'all',
+      price: 'all'
+    },
+    sort: 'default',
+    cart: loadCart(),
+    modalProduct: null,
+    modalImageIndex: 0,
+    lastFocusedElement: null
+  };
+
+  function initBranding() {
+    document.title = `${BRAND_NAME} | ${TAGLINE}`;
+    document.querySelector('meta[name="description"]').setAttribute('content', `${BRAND_NAME}, catálogo de joyería fina y moderna.`);
+    document.querySelector('meta[property="og:title"]').setAttribute('content', BRAND_NAME);
+    document.getElementById('hero-title').textContent = TAGLINE;
+    const phoneDigits = PHONE_WHATSAPP.replace(/[^\d]/g, '');
+    selectors.whatsapp.href = `https://wa.me/${phoneDigits}?text=Hola%20${encodeURIComponent(BRAND_NAME)},%20quiero%20más%20información`;
+    document.querySelectorAll('[data-phone]').forEach((anchor) => {
+      anchor.href = `tel:${phoneDigits}`;
+      anchor.textContent = PHONE_WHATSAPP;
+    });
+    document.querySelectorAll('[data-email]').forEach((anchor) => {
+      anchor.href = `mailto:${EMAIL}`;
+      anchor.textContent = EMAIL;
+    });
+    selectors.year.textContent = new Date().getFullYear();
+  }
+
+  function populateFilters() {
+    const categories = Array.from(new Set(PRODUCTS.map((p) => p.categoria)));
+    const materials = Array.from(new Set(PRODUCTS.map((p) => p.material)));
+
+    categories.forEach((cat) => {
+      const option = document.createElement('option');
+      option.value = cat;
+      option.textContent = cat;
+      selectors.filterCategory.appendChild(option);
+    });
+
+    materials.forEach((mat) => {
+      const option = document.createElement('option');
+      option.value = mat;
+      option.textContent = mat;
+      selectors.filterMaterial.appendChild(option);
+    });
+  }
+
+  function applyFilters() {
+    state.filteredProducts = state.products.filter((product) => {
+      const matchesSearch = product.nombre.toLowerCase().includes(state.search) || product.descripcion.toLowerCase().includes(state.search);
+      if (!matchesSearch) return false;
+      const matchesCategory = state.filters.category === 'all' || product.categoria === state.filters.category;
+      const matchesMaterial = state.filters.material === 'all' || product.material === state.filters.material;
+      const matchesPrice = filterPrice(product.precio);
+      return matchesCategory && matchesMaterial && matchesPrice;
+    });
+    applySort();
+    renderProductGrid();
+  }
+
+  function filterPrice(price) {
+    switch (state.filters.price) {
+      case 'under150':
+        return price < 150;
+      case '150-300':
+        return price >= 150 && price <= 300;
+      case '300-600':
+        return price > 300 && price <= 600;
+      case 'above600':
+        return price > 600;
+      default:
+        return true;
+    }
+  }
+
+  function applySort() {
+    const sort = state.sort;
+    state.filteredProducts.sort((a, b) => {
+      if (sort === 'price-asc') {
+        return getFinalPrice(a) - getFinalPrice(b);
+      }
+      if (sort === 'price-desc') {
+        return getFinalPrice(b) - getFinalPrice(a);
+      }
+      if (sort === 'newest') {
+        return Number(b.nuevo) - Number(a.nuevo);
+      }
+      return a.nombre.localeCompare(b.nombre);
+    });
+  }
+
+  function createStars(rating) {
+    const stars = [];
+    for (let i = 1; i <= 5; i += 1) {
+      stars.push(`<span aria-hidden="true">${i <= Math.round(rating) ? '★' : '☆'}</span>`);
+    }
+    return `<div class="card__rating" aria-label="Calificación ${rating.toFixed(1)} de 5">${stars.join('')}</div>`;
+  }
+
+  function renderProductGrid() {
+    selectors.productGrid.innerHTML = '';
+    if (!state.filteredProducts.length) {
+      const empty = document.createElement('p');
+      empty.textContent = 'No encontramos resultados para tu búsqueda. Ajusta los filtros para ver más piezas.';
+      empty.className = 'catalogo__empty';
+      selectors.productGrid.appendChild(empty);
+      return;
+    }
+
+    state.filteredProducts.forEach((product) => {
+      const card = document.createElement('article');
+      card.className = 'card';
+      const finalPrice = getFinalPrice(product);
+      const hasDiscount = finalPrice !== product.precio;
+      card.innerHTML = `
+        <div class="card__img">
+          ${product.nuevo ? '<span class="card__badge">Nuevo</span>' : ''}
+          <img src="${product.imagenes[0]}" alt="${product.nombre}" loading="lazy" width="320" height="320">
+        </div>
+        <h3 class="card__title">${product.nombre}</h3>
+        <div class="card__price">${hasDiscount ? `<del>${formatCurrency(product.precio)}</del>` : ''}<span>${formatCurrency(finalPrice)}</span></div>
+        ${createStars(product.rating)}
+        <div class="card__actions">
+          <button class="btn btn--outline" data-action="detail" data-id="${product.id}">Ver detalle</button>
+          <button class="btn btn--primary" data-action="add" data-id="${product.id}">Agregar</button>
+        </div>
+      `;
+      selectors.productGrid.appendChild(card);
+    });
+  }
+
+  function openModal(product, trigger) {
+    state.modalProduct = product;
+    state.modalImageIndex = 0;
+    state.lastFocusedElement = trigger || document.activeElement;
+    updateModal();
+    selectors.modal.hidden = false;
+    document.body.classList.add('is-locked');
+    selectors.modal.setAttribute('data-open', 'true');
+    trapFocus(selectors.modal.querySelector('.modal__content'));
+    selectors.modal.querySelector('.modal__close').focus();
+  }
+
+  function closeModal() {
+    if (selectors.modal.hidden) return;
+    selectors.modal.hidden = true;
+    selectors.modal.removeAttribute('data-open');
+    document.body.classList.remove('is-locked');
+    releaseFocus();
+    if (state.lastFocusedElement) {
+      state.lastFocusedElement.focus();
+    }
+  }
+
+  function updateModal() {
+    const product = state.modalProduct;
+    if (!product) return;
+    selectors.modalTitle.textContent = product.nombre;
+    selectors.modalDescription.textContent = product.descripcion;
+    selectors.modalMaterial.textContent = product.material;
+    selectors.modalSize.textContent = product.talla;
+    selectors.modalWeight.textContent = product.peso;
+    selectors.modalStock.textContent = `${product.stock} disponibles`;
+    selectors.modalImage.src = product.imagenes[state.modalImageIndex];
+    selectors.modalImage.alt = `${product.nombre} vista ${state.modalImageIndex + 1}`;
+    selectors.modalQuantity.value = 1;
+    const finalPrice = getFinalPrice(product);
+    selectors.modalPrice.innerHTML = `${finalPrice !== product.precio ? `<del>${formatCurrency(product.precio)}</del>` : ''}<span>${formatCurrency(finalPrice)}</span>`;
+  }
+
+  function addToCart(product, quantity) {
+    const normalizedQty = sanitizeQuantity(quantity, product.stock, true);
+    const finalPrice = getFinalPrice(product);
+    const existing = state.cart.find((item) => item.id === product.id);
+    if (existing) {
+      existing.cantidad = Math.min(existing.cantidad + normalizedQty, Math.min(product.stock, 99));
+    } else {
+      state.cart.push({
+        id: product.id,
+        nombre: product.nombre,
+        precioBase: product.precio,
+        precioFinal: finalPrice,
+        cantidad: normalizedQty,
+        imagen: product.imagenes[0],
+        nuevo: product.nuevo,
+        stock: product.stock
+      });
+    }
+    saveCart();
+    renderCart();
+  }
+
+  function removeFromCart(id) {
+    state.cart = state.cart.filter((item) => item.id !== id);
+    saveCart();
+    renderCart();
+  }
+
+  function updateCartQuantity(id, value) {
+    const item = state.cart.find((i) => i.id === id);
+    if (!item) return;
+    const sanitized = sanitizeQuantity(value, item.stock);
+    if (sanitized === null) {
+      return;
+    }
+    item.cantidad = sanitized;
+    saveCart();
+    renderCart();
+  }
+
+  function forceCartQuantity(id, value) {
+    const item = state.cart.find((i) => i.id === id);
+    if (!item) return;
+    const sanitized = sanitizeQuantity(value, item.stock, true);
+    item.cantidad = sanitized;
+    saveCart();
+    renderCart();
+  }
+
+  function calculateTotals() {
+    return state.cart.reduce(
+      (acc, item) => {
+        const lineSubtotal = item.precioFinal * item.cantidad;
+        const lineDiscount = (item.precioBase - item.precioFinal) * item.cantidad;
+        acc.subtotal += item.precioBase * item.cantidad;
+        acc.discount += lineDiscount;
+        acc.total += lineSubtotal;
+        return acc;
+      },
+      { subtotal: 0, discount: 0, total: 0 }
+    );
+  }
+
+  function renderCart() {
+    selectors.cartItems.innerHTML = '';
+    if (!state.cart.length) {
+      const empty = document.createElement('p');
+      empty.textContent = 'Tu carrito está vacío. Agrega productos para continuar.';
+      empty.className = 'cart__empty';
+      selectors.cartItems.appendChild(empty);
+    } else {
+      state.cart.forEach((item) => {
+        const row = document.createElement('article');
+        row.className = 'cart-item';
+        row.innerHTML = `
+          <div class="cart-item__thumb"><img src="${item.imagen}" alt="${item.nombre}" loading="lazy" width="72" height="72"></div>
+          <div class="cart-item__info">
+            <div class="cart-item__title">${item.nombre}</div>
+            <div class="cart-item__price">${formatCurrency(item.precioFinal)} ${item.nuevo ? '<span class="badge">-10%</span>' : ''}</div>
+            <div class="cart-item__controls">
+              <button type="button" data-cart-decrease data-id="${item.id}">−</button>
+              <input type="number" inputmode="numeric" min="1" max="${Math.min(item.stock, 99)}" value="${item.cantidad}" data-cart-qty data-id="${item.id}">
+              <button type="button" data-cart-increase data-id="${item.id}">+</button>
+              <button type="button" data-cart-remove data-id="${item.id}" aria-label="Eliminar ${item.nombre}">✕</button>
+            </div>
+          </div>
+        `;
+        selectors.cartItems.appendChild(row);
+      });
+    }
+
+    const totals = calculateTotals();
+    selectors.cartSubtotal.textContent = formatCurrency(totals.subtotal);
+    selectors.cartDiscount.textContent = totals.discount ? `− ${formatCurrency(totals.discount)}` : formatCurrency(0);
+    selectors.cartTotal.textContent = formatCurrency(totals.total);
+    selectors.cartCount.textContent = state.cart.reduce((sum, item) => sum + item.cantidad, 0);
+    updateSummary(totals);
+  }
+
+  function updateSummary(totals) {
+    selectors.summaryBody.innerHTML = '';
+    if (!state.cart.length) {
+      const empty = document.createElement('tr');
+      empty.innerHTML = '<td colspan="3">Tu carrito está vacío.</td>';
+      selectors.summaryBody.appendChild(empty);
+    } else {
+      state.cart.forEach((item) => {
+        const tr = document.createElement('tr');
+        tr.innerHTML = `
+          <td>${item.nombre}</td>
+          <td>${item.cantidad}</td>
+          <td>${formatCurrency(item.precioFinal * item.cantidad)}</td>
+        `;
+        selectors.summaryBody.appendChild(tr);
+      });
+    }
+    selectors.summarySubtotal.textContent = formatCurrency(totals.subtotal);
+    selectors.summaryDiscount.textContent = totals.discount ? `− ${formatCurrency(totals.discount)}` : formatCurrency(0);
+    selectors.summaryTotal.textContent = formatCurrency(totals.total);
+  }
+
+  function openCart(trigger) {
+    state.lastFocusedElement = trigger || document.activeElement;
+    selectors.cartPanel.hidden = false;
+    document.body.classList.add('is-locked');
+    trapFocus(selectors.cartPanel.querySelector('.cart__content'));
+    selectors.cartPanel.querySelector('.cart__close').focus();
+  }
+
+  function closeCart() {
+    if (selectors.cartPanel.hidden) return;
+    selectors.cartPanel.hidden = true;
+    document.body.classList.remove('is-locked');
+    releaseFocus();
+    if (state.lastFocusedElement) {
+      state.lastFocusedElement.focus();
+    }
+  }
+
+  function trapFocus(container) {
+    const focusable = Array.from(
+      container.querySelectorAll(
+        'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
+      )
+    ).filter((el) => !el.hasAttribute('disabled'));
+    if (!focusable.length) return;
+
+    let first = focusable[0];
+    let last = focusable[focusable.length - 1];
+
+    function handleKeydown(event) {
+      if (event.key === 'Tab') {
+        if (event.shiftKey && document.activeElement === first) {
+          event.preventDefault();
+          last.focus();
+        } else if (!event.shiftKey && document.activeElement === last) {
+          event.preventDefault();
+          first.focus();
+        }
+      }
+      if (event.key === 'Escape') {
+        if (!selectors.modal.hidden) {
+          closeModal();
+        }
+        if (!selectors.cartPanel.hidden) {
+          closeCart();
+        }
+      }
+    }
+
+    container.addEventListener('keydown', handleKeydown);
+    container.setAttribute('data-trap', 'true');
+    container.dataset.firstFocus = first;
+    container.dataset.lastFocus = last;
+    container.__handleKeydown = handleKeydown;
+  }
+
+  function releaseFocus() {
+    document.querySelectorAll('[data-trap="true"]').forEach((container) => {
+      container.removeEventListener('keydown', container.__handleKeydown);
+      delete container.__handleKeydown;
+      container.removeAttribute('data-trap');
+      delete container.dataset.firstFocus;
+      delete container.dataset.lastFocus;
+    });
+  }
+
+  function handleProductGridClick(event) {
+    const target = event.target.closest('button[data-action]');
+    if (!target) return;
+    const product = state.products.find((p) => p.id === target.dataset.id);
+    if (!product) return;
+    if (target.dataset.action === 'detail') {
+      openModal(product, target);
+    } else if (target.dataset.action === 'add') {
+      addToCart(product, 1);
+      openCart(target);
+    }
+  }
+
+  function handleModalNavigation(event) {
+    if (!state.modalProduct) return;
+    if (event.target.matches('[data-gallery-next]')) {
+      state.modalImageIndex = (state.modalImageIndex + 1) % state.modalProduct.imagenes.length;
+      updateModal();
+    }
+    if (event.target.matches('[data-gallery-prev]')) {
+      state.modalImageIndex = (state.modalImageIndex - 1 + state.modalProduct.imagenes.length) % state.modalProduct.imagenes.length;
+      updateModal();
+    }
+    if (event.target.matches('[data-close-modal]')) {
+      closeModal();
+    }
+  }
+
+  function handleModalQuantity(event) {
+    if (!state.modalProduct) return;
+    if (event.target.matches('[data-qty-increase]')) {
+      const next = sanitizeQuantity(Number(selectors.modalQuantity.value) + 1, state.modalProduct.stock, true);
+      selectors.modalQuantity.value = next;
+    }
+    if (event.target.matches('[data-qty-decrease]')) {
+      const next = sanitizeQuantity(Number(selectors.modalQuantity.value) - 1, state.modalProduct.stock, true);
+      selectors.modalQuantity.value = next;
+    }
+  }
+
+  function handleModalAdd() {
+    if (!state.modalProduct) return;
+    addToCart(state.modalProduct, selectors.modalQuantity.value);
+    closeModal();
+    openCart(selectors.cartButton);
+  }
+
+  function handleCartInteraction(event) {
+    const decrease = event.target.closest('[data-cart-decrease]');
+    const increase = event.target.closest('[data-cart-increase]');
+    const remove = event.target.closest('[data-cart-remove]');
+    const input = event.target.closest('[data-cart-qty]');
+
+    if (decrease) {
+      const id = decrease.dataset.id;
+      const item = state.cart.find((i) => i.id === id);
+      if (!item) return;
+      forceCartQuantity(id, item.cantidad - 1);
+    }
+    if (increase) {
+      const id = increase.dataset.id;
+      const item = state.cart.find((i) => i.id === id);
+      if (!item) return;
+      forceCartQuantity(id, item.cantidad + 1);
+    }
+    if (remove) {
+      removeFromCart(remove.dataset.id);
+    }
+    if (input) {
+      updateCartQuantity(input.dataset.id, input.value);
+    }
+  }
+
+  function handleCartQuantityBlur(event) {
+    const input = event.target.closest('[data-cart-qty]');
+    if (!input) return;
+    forceCartQuantity(input.dataset.id, input.value);
+  }
+
+  function handleSearch(event) {
+    state.search = event.target.value.trim().toLowerCase();
+    applyFilters();
+  }
+
+  function handleFilterChange() {
+    state.filters.category = selectors.filterCategory.value;
+    state.filters.material = selectors.filterMaterial.value;
+    state.filters.price = selectors.filterPrice.value;
+    applyFilters();
+  }
+
+  function handleSortChange() {
+    state.sort = selectors.sort.value;
+    applySort();
+    renderProductGrid();
+  }
+
+  function handleCheckoutNavigate() {
+    closeCart();
+    document.getElementById('checkout').scrollIntoView({ behavior: 'smooth' });
+    selectors.checkoutForm.querySelector('input, textarea, select').focus({ preventScroll: true });
+  }
+
+  function validateForm() {
+    let valid = true;
+    selectors.formFeedback.textContent = '';
+    if (!state.cart.length) {
+      selectors.formFeedback.textContent = 'Tu carrito está vacío. Agrega productos antes de confirmar el pedido.';
+      return false;
+    }
+    Array.from(selectors.checkoutForm.elements).forEach((field) => {
+      if (field.hasAttribute('required')) {
+        if (!field.value.trim()) {
+          field.classList.add('invalid');
+          valid = false;
+        } else {
+          field.classList.remove('invalid');
+        }
+      }
+      if (field.type === 'email' && field.value) {
+        const emailValid = /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(field.value);
+        if (!emailValid) {
+          field.classList.add('invalid');
+          valid = false;
+        }
+      }
+      if (field.type === 'tel' && field.value) {
+        const phoneValid = /[\d\s+()-]{6,}/.test(field.value);
+        if (!phoneValid) {
+          field.classList.add('invalid');
+          valid = false;
+        }
+      }
+    });
+    if (!valid) {
+      selectors.formFeedback.textContent = 'Revisa los campos obligatorios y verifica tu email y teléfono.';
+    }
+    return valid;
+  }
+
+  function handleCheckoutSubmit(event) {
+    event.preventDefault();
+    if (!validateForm()) return;
+    const orderId = `JF-${Math.floor(Math.random() * 900000 + 100000)}`;
+    selectors.orderNumber.textContent = `Número de pedido: ${orderId}`;
+    selectors.checkoutSuccess.hidden = false;
+    selectors.formFeedback.textContent = '¡Gracias! Hemos registrado tu pedido. Te contactaremos en breve.';
+    selectors.checkoutForm.reset();
+    state.cart = [];
+    saveCart();
+    renderCart();
+  }
+
+  function handlePrint() {
+    window.print();
+  }
+
+  function setupMenu() {
+    if (!selectors.toggle) return;
+    selectors.toggle.addEventListener('click', () => {
+      const expanded = selectors.toggle.getAttribute('aria-expanded') === 'true';
+      selectors.toggle.setAttribute('aria-expanded', String(!expanded));
+      selectors.menu.setAttribute('aria-expanded', String(!expanded));
+      selectors.menu.style.display = expanded ? 'none' : 'grid';
+    });
+  }
+
+  function setupEventListeners() {
+    selectors.productGrid.addEventListener('click', handleProductGridClick);
+    selectors.modal.addEventListener('click', handleModalNavigation);
+    selectors.modal.addEventListener('click', handleModalQuantity);
+    selectors.modalAdd.addEventListener('click', handleModalAdd);
+    selectors.cartButton.addEventListener('click', (event) => openCart(event.currentTarget));
+    selectors.cartPanel.addEventListener('click', (event) => {
+      if (event.target.matches('[data-close-cart]')) {
+        closeCart();
+      }
+    });
+    selectors.cartItems.addEventListener('click', handleCartInteraction);
+    selectors.cartItems.addEventListener('input', handleCartInteraction);
+    selectors.cartItems.addEventListener('blur', handleCartQuantityBlur, true);
+    selectors.goCheckout.addEventListener('click', handleCheckoutNavigate);
+    selectors.search.addEventListener('input', handleSearch);
+    selectors.filterCategory.addEventListener('change', handleFilterChange);
+    selectors.filterMaterial.addEventListener('change', handleFilterChange);
+    selectors.filterPrice.addEventListener('change', handleFilterChange);
+    selectors.sort.addEventListener('change', handleSortChange);
+    selectors.checkoutForm.addEventListener('submit', handleCheckoutSubmit);
+    selectors.printButton.addEventListener('click', handlePrint);
+    document.addEventListener('keydown', (event) => {
+      if (event.key === 'Escape') {
+        closeModal();
+        closeCart();
+      }
+    });
+    selectors.modal.addEventListener('click', (event) => {
+      if (event.target === selectors.modal.querySelector('.modal__overlay')) {
+        closeModal();
+      }
+    });
+  }
+
+  function init() {
+    initBranding();
+    populateFilters();
+    applyFilters();
+    renderCart();
+    setupMenu();
+    setupEventListeners();
+  }
+
+  init();
+})();

--- a/assets/js/data.js
+++ b/assets/js/data.js
@@ -1,0 +1,238 @@
+const PRODUCTS = [
+  {
+    id: 'anillo-aurora',
+    nombre: 'Anillo Aurora',
+    slug: 'anillo-aurora',
+    categoria: 'Anillos',
+    material: 'Oro',
+    precio: 450,
+    rating: 4.8,
+    nuevo: true,
+    stock: 12,
+    talla: '6-8',
+    peso: '4 g',
+    descripcion: 'Anillo en oro amarillo de 18k con incrustaciones de brillantes corte baguette.',
+    imagenes: [
+      'assets/img/products/product-1.jpg',
+      'assets/img/products/product-2.jpg',
+      'assets/img/products/product-3.jpg'
+    ]
+  },
+  {
+    id: 'anillo-solstice',
+    nombre: 'Anillo Solstice',
+    slug: 'anillo-solstice',
+    categoria: 'Anillos',
+    material: 'Plata',
+    precio: 180,
+    rating: 4.6,
+    nuevo: false,
+    stock: 20,
+    talla: '5-9',
+    peso: '3 g',
+    descripcion: 'Plata 925 con baño de rodio y circonias de alto brillo en patrón envolvente.',
+    imagenes: [
+      'assets/img/products/product-2.jpg',
+      'assets/img/products/product-3.jpg',
+      'assets/img/products/product-4.jpg'
+    ]
+  },
+  {
+    id: 'collar-constella',
+    nombre: 'Collar Constella',
+    slug: 'collar-constella',
+    categoria: 'Collares',
+    material: 'Oro',
+    precio: 620,
+    rating: 4.9,
+    nuevo: true,
+    stock: 8,
+    talla: '45 cm',
+    peso: '12 g',
+    descripcion: 'Collar de oro amarillo de 18k con dije central inspirado en constelaciones.',
+    imagenes: [
+      'assets/img/products/product-3.jpg',
+      'assets/img/products/product-4.jpg',
+      'assets/img/products/product-5.jpg'
+    ]
+  },
+  {
+    id: 'collar-luna-nova',
+    nombre: 'Collar Luna Nova',
+    slug: 'collar-luna-nova',
+    categoria: 'Collares',
+    material: 'Plata',
+    precio: 260,
+    rating: 4.7,
+    nuevo: false,
+    stock: 16,
+    talla: '42 cm',
+    peso: '9 g',
+    descripcion: 'Collar de plata 925 con baño de rodio y dije de madreperla tallada.',
+    imagenes: [
+      'assets/img/products/product-4.jpg',
+      'assets/img/products/product-5.jpg',
+      'assets/img/products/product-6.jpg'
+    ]
+  },
+  {
+    id: 'aretes-aurum',
+    nombre: 'Aretes Aurum',
+    slug: 'aretes-aurum',
+    categoria: 'Aretes',
+    material: 'Oro',
+    precio: 340,
+    rating: 4.5,
+    nuevo: false,
+    stock: 24,
+    talla: '2 cm',
+    peso: '6 g',
+    descripcion: 'Aretes tipo aro en oro amarillo con textura martillada de acabado espejo.',
+    imagenes: [
+      'assets/img/products/product-5.jpg',
+      'assets/img/products/product-6.jpg',
+      'assets/img/products/product-1.jpg'
+    ]
+  },
+  {
+    id: 'aretes-nebula',
+    nombre: 'Aretes Nebula',
+    slug: 'aretes-nebula',
+    categoria: 'Aretes',
+    material: 'Plata',
+    precio: 150,
+    rating: 4.4,
+    nuevo: true,
+    stock: 30,
+    talla: '3 cm',
+    peso: '5 g',
+    descripcion: 'Aretes colgantes en plata 925 con cristales flotantes en degradé.',
+    imagenes: [
+      'assets/img/products/product-6.jpg',
+      'assets/img/products/product-1.jpg',
+      'assets/img/products/product-2.jpg'
+    ]
+  },
+  {
+    id: 'pulsera-eden',
+    nombre: 'Pulsera Eden',
+    slug: 'pulsera-eden',
+    categoria: 'Pulseras',
+    material: 'Oro',
+    precio: 520,
+    rating: 4.8,
+    nuevo: false,
+    stock: 10,
+    talla: '18 cm',
+    peso: '14 g',
+    descripcion: 'Pulsera articulada en oro amarillo con eslabones geométricos pulidos.',
+    imagenes: [
+      'assets/img/products/product-1.jpg',
+      'assets/img/products/product-3.jpg',
+      'assets/img/products/product-5.jpg'
+    ]
+  },
+  {
+    id: 'pulsera-luz',
+    nombre: 'Pulsera Luz',
+    slug: 'pulsera-luz',
+    categoria: 'Pulseras',
+    material: 'Plata',
+    precio: 210,
+    rating: 4.5,
+    nuevo: false,
+    stock: 18,
+    talla: '19 cm',
+    peso: '11 g',
+    descripcion: 'Pulsera de plata 925 con baño de rodio y charms intercambiables.',
+    imagenes: [
+      'assets/img/products/product-2.jpg',
+      'assets/img/products/product-4.jpg',
+      'assets/img/products/product-6.jpg'
+    ]
+  },
+  {
+    id: 'anillo-aurora-rosa',
+    nombre: 'Anillo Aurora Rosa',
+    slug: 'anillo-aurora-rosa',
+    categoria: 'Anillos',
+    material: 'Oro Rosa',
+    precio: 490,
+    rating: 4.9,
+    nuevo: true,
+    stock: 9,
+    talla: '6-7',
+    peso: '4 g',
+    descripcion: 'Oro rosa de 18k con diamantes champagne y banda ergonómica.',
+    imagenes: [
+      'assets/img/products/product-3.jpg',
+      'assets/img/products/product-4.jpg',
+      'assets/img/products/product-5.jpg'
+    ]
+  },
+  {
+    id: 'collar-helia',
+    nombre: 'Collar Helia',
+    slug: 'collar-helia',
+    categoria: 'Collares',
+    material: 'Acero',
+    precio: 130,
+    rating: 4.3,
+    nuevo: false,
+    stock: 25,
+    talla: '50 cm',
+    peso: '16 g',
+    descripcion: 'Acero quirúrgico hipoalergénico con baño en oro rosa y dije solar.',
+    imagenes: [
+      'assets/img/products/product-4.jpg',
+      'assets/img/products/product-5.jpg',
+      'assets/img/products/product-6.jpg'
+    ]
+  },
+  {
+    id: 'aretes-zenit',
+    nombre: 'Aretes Zénit',
+    slug: 'aretes-zenit',
+    categoria: 'Aretes',
+    material: 'Acero',
+    precio: 95,
+    rating: 4.2,
+    nuevo: false,
+    stock: 40,
+    talla: '1.5 cm',
+    peso: '4 g',
+    descripcion: 'Mini aros en acero quirúrgico con baño en oro amarillo y cierre seguro.',
+    imagenes: [
+      'assets/img/products/product-5.jpg',
+      'assets/img/products/product-6.jpg',
+      'assets/img/products/product-1.jpg'
+    ]
+  },
+  {
+    id: 'pulsera-orbita',
+    nombre: 'Pulsera Órbita',
+    slug: 'pulsera-orbita',
+    categoria: 'Pulseras',
+    material: 'Acero',
+    precio: 160,
+    rating: 4.4,
+    nuevo: true,
+    stock: 22,
+    talla: '20 cm',
+    peso: '13 g',
+    descripcion: 'Pulsera en acero con esferas flotantes y baño en oro blanco.',
+    imagenes: [
+      'assets/img/products/product-6.jpg',
+      'assets/img/products/product-1.jpg',
+      'assets/img/products/product-2.jpg'
+    ]
+  }
+];
+
+const BRAND_CONFIG = {
+  BRAND_NAME: 'JF Joyas',
+  TAGLINE: 'Elegancia que perdura',
+  CURRENCY: 'USD',
+  PHONE_WHATSAPP: '+593 99 999 9999',
+  EMAIL: 'ventas@jfjoyas.com'
+};

--- a/index.html
+++ b/index.html
@@ -1,41 +1,328 @@
 <!DOCTYPE html>
-<html lang="en">
-  <head>
-    <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Valeska Ponce | Joyería</title>
-    <script src="https://cdn.tailwindcss.com"></script>
-    <script>
-      tailwind.config = {
-        theme: {
-          extend: {
-            colors: {
-              'vp-gold': '#C8A96A',
-              'vp-black': '#1A1A1A',
-              'vp-ivory': '#FAF7F2',
-            },
-            fontFamily: {
-              sans: ['"Segoe UI"', 'Roboto', '"Helvetica Neue"', 'Arial', 'sans-serif'],
-            }
-          }
-        }
-      }
-    </script>
-    <link rel="stylesheet" href="./index.css">
-    <link rel="icon" href="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>💍</text></svg>">
-  <script src="https://unpkg.com/@babel/standalone/babel.min.js"></script>
-  <script type="importmap">
-{
-  "imports": {
-    "react": "https://esm.sh/react@18.2.0",
-    "react-dom/client": "https://esm.sh/react-dom@18.2.0/client",
-    "react-dom/": "https://aistudiocdn.com/react-dom@^19.1.1/"
-  }
-}
-</script>
+<html lang="es">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>JF Joyas | Elegancia que perdura</title>
+  <meta name="description" content="JF Joyas, catálogo de joyería fina en oro, plata y acero. Descubre anillos, collares, aretes y pulseras con estilo moderno y sofisticado.">
+  <meta property="og:title" content="JF Joyas">
+  <meta property="og:description" content="Elegancia que perdura en cada pieza de joyería.">
+  <meta property="og:type" content="website">
+  <meta property="og:image" content="assets/img/hero.jpg">
+  <meta property="og:url" content="https://jfjoyas.com">
+  <link rel="stylesheet" href="assets/css/styles.css">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
 </head>
-  <body class="bg-vp-ivory">
-    <div id="root"></div>
-    <script type="text/babel" data-type="module" src="./index.jsx"></script>
-  </body>
+<body>
+  <a class="skip-link" href="#catalogo">Saltar al catálogo</a>
+  <header class="header" id="inicio">
+    <div class="header__inner">
+      <a href="#inicio" class="header__logo" aria-label="Inicio JF Joyas">
+        <img src="assets/img/logo.svg" alt="JF Joyas" width="120" height="32">
+      </a>
+      <nav class="header__nav" aria-label="Principal">
+        <button class="header__toggle" aria-expanded="false" aria-controls="menu">☰</button>
+        <ul class="header__menu" id="menu">
+          <li><a href="#inicio">Inicio</a></li>
+          <li><a href="#catalogo">Catálogo</a></li>
+          <li><a href="#sobre-nosotros">Sobre Nosotros</a></li>
+          <li><a href="#testimonios">Testimonios</a></li>
+          <li><a href="#faq">FAQ</a></li>
+          <li><a href="#contacto">Contacto</a></li>
+          <li><button class="header__cart-btn" data-open-cart>Carrito<span class="header__cart-count" aria-live="polite">0</span></button></li>
+        </ul>
+      </nav>
+    </div>
+  </header>
+
+  <main>
+    <section class="hero" aria-labelledby="hero-title">
+      <div class="hero__content">
+        <h1 id="hero-title">Elegancia que perdura</h1>
+        <p>Descubre piezas únicas que combinan lujo, diseño moderno y artesanía de excelencia.</p>
+        <a class="btn btn--primary" href="#catalogo">Ver catálogo</a>
+      </div>
+      <div class="hero__media" aria-hidden="true">
+        <img src="assets/img/hero.jpg" alt="Colección de joyas JF" width="800" height="600" loading="lazy">
+      </div>
+    </section>
+
+    <section class="catalogo" id="catalogo" aria-labelledby="catalogo-title">
+      <div class="section-header">
+        <h2 id="catalogo-title">Catálogo Destacado</h2>
+        <p>Explora nuestra colección seleccionada de anillos, collares, aretes y pulseras.</p>
+      </div>
+      <div class="catalogo__toolbar" role="region" aria-label="Herramientas de búsqueda y filtrado">
+        <label class="field">
+          <span class="field__label">Buscar</span>
+          <input type="search" id="search" placeholder="Busca por nombre o características" aria-label="Buscar joyas">
+        </label>
+        <label class="field">
+          <span class="field__label">Categoría</span>
+          <select id="filter-category" aria-label="Filtrar por categoría">
+            <option value="all">Todas</option>
+          </select>
+        </label>
+        <label class="field">
+          <span class="field__label">Material</span>
+          <select id="filter-material" aria-label="Filtrar por material">
+            <option value="all">Todos</option>
+          </select>
+        </label>
+        <label class="field">
+          <span class="field__label">Precio</span>
+          <select id="filter-price" aria-label="Filtrar por precio">
+            <option value="all">Todos</option>
+            <option value="under150">Hasta 150 USD</option>
+            <option value="150-300">150 - 300 USD</option>
+            <option value="300-600">300 - 600 USD</option>
+            <option value="above600">Más de 600 USD</option>
+          </select>
+        </label>
+        <label class="field">
+          <span class="field__label">Ordenar</span>
+          <select id="sort" aria-label="Ordenar catálogo">
+            <option value="default">Destacados</option>
+            <option value="price-asc">Precio: menor a mayor</option>
+            <option value="price-desc">Precio: mayor a menor</option>
+            <option value="newest">Nuevos</option>
+          </select>
+        </label>
+      </div>
+      <div class="catalogo__grid" id="product-grid" aria-live="polite"></div>
+    </section>
+
+    <section class="about" id="sobre-nosotros" aria-labelledby="sobre-title">
+      <div class="section-header">
+        <h2 id="sobre-title">Sobre JF Joyas</h2>
+        <p>Más de 15 años creando joyería de lujo con materiales certificados.</p>
+      </div>
+      <div class="about__grid">
+        <article class="about__card">
+          <h3>Diseño personalizado</h3>
+          <p>Creamos piezas únicas para bodas, aniversarios y momentos inolvidables con asesoría especializada.</p>
+        </article>
+        <article class="about__card">
+          <h3>Materiales certificados</h3>
+          <p>Trabajamos con oro de 18k, plata 925 y acero quirúrgico hipoalergénico de alta durabilidad.</p>
+        </article>
+        <article class="about__card">
+          <h3>Garantía y servicio</h3>
+          <p>Ofrecemos mantenimiento, limpieza y ajustes gratuitos durante el primer año de tu compra.</p>
+        </article>
+      </div>
+    </section>
+
+    <section class="testimonios" id="testimonios" aria-labelledby="testimonios-title">
+      <div class="section-header">
+        <h2 id="testimonios-title">Testimonios</h2>
+        <p>Clientes que ya disfrutan de la elegancia de JF Joyas.</p>
+      </div>
+      <div class="testimonios__grid">
+        <figure class="testimonial">
+          <blockquote>“Recibí mi anillo de compromiso y superó todas mis expectativas. La atención fue impecable.”</blockquote>
+          <figcaption>— Daniela P.</figcaption>
+        </figure>
+        <figure class="testimonial">
+          <blockquote>“La calidad es excepcional y la presentación increíble. Definitivamente volveré a comprar.”</blockquote>
+          <figcaption>— Andrés R.</figcaption>
+        </figure>
+        <figure class="testimonial">
+          <blockquote>“Me guiaron en todo el proceso de personalización de un collar. El resultado es una obra de arte.”</blockquote>
+          <figcaption>— Sofía L.</figcaption>
+        </figure>
+      </div>
+    </section>
+
+    <section class="faq" id="faq" aria-labelledby="faq-title">
+      <div class="section-header">
+        <h2 id="faq-title">Preguntas frecuentes</h2>
+      </div>
+      <div class="faq__items">
+        <details>
+          <summary>¿Ofrecen envíos internacionales?</summary>
+          <p>Sí, enviamos a toda Latinoamérica con seguros de transporte y seguimiento en tiempo real.</p>
+        </details>
+        <details>
+          <summary>¿Cómo funciona la garantía?</summary>
+          <p>Todas las piezas incluyen garantía de un año que cubre limpieza, pulido y ajustes de talla.</p>
+        </details>
+        <details>
+          <summary>¿Puedo personalizar una joya?</summary>
+          <p>Por supuesto. Agenda una cita con nuestros asesores para crear un diseño exclusivo.</p>
+        </details>
+      </div>
+    </section>
+
+    <section class="checkout" id="checkout" aria-labelledby="checkout-title">
+      <div class="section-header">
+        <h2 id="checkout-title">Checkout</h2>
+        <p>Completa tus datos para finalizar el pedido.</p>
+      </div>
+      <div class="checkout__layout">
+        <form class="checkout__form" id="checkout-form" novalidate>
+          <div class="form-group">
+            <label for="cliente-nombre">Nombre completo*</label>
+            <input id="cliente-nombre" name="nombre" type="text" required autocomplete="name" placeholder="Tu nombre">
+          </div>
+          <div class="form-group">
+            <label for="cliente-email">Email*</label>
+            <input id="cliente-email" name="email" type="email" required autocomplete="email" placeholder="tu@email.com">
+          </div>
+          <div class="form-group">
+            <label for="cliente-telefono">Teléfono / WhatsApp*</label>
+            <input id="cliente-telefono" name="telefono" type="tel" required autocomplete="tel" placeholder="099 999 9999">
+          </div>
+          <div class="form-group">
+            <label for="cliente-direccion">Dirección*</label>
+            <input id="cliente-direccion" name="direccion" type="text" required autocomplete="street-address" placeholder="Calle principal y referencia">
+          </div>
+          <div class="form-group">
+            <label for="cliente-ciudad">Ciudad*</label>
+            <input id="cliente-ciudad" name="ciudad" type="text" required autocomplete="address-level2" placeholder="Ciudad">
+          </div>
+          <div class="form-group">
+            <label for="cliente-notas">Notas</label>
+            <textarea id="cliente-notas" name="notas" rows="3" placeholder="Indicaciones adicionales"></textarea>
+          </div>
+          <button class="btn btn--primary" type="submit">Confirmar pedido</button>
+          <p class="form-helper">Campos marcados con * son obligatorios.</p>
+          <div class="form-feedback" aria-live="polite"></div>
+        </form>
+        <aside class="checkout__summary" aria-live="polite">
+          <h3>Resumen del pedido</h3>
+          <table class="summary-table">
+            <thead>
+              <tr>
+                <th scope="col">Producto</th>
+                <th scope="col">Cant.</th>
+                <th scope="col">Subtotal</th>
+              </tr>
+            </thead>
+            <tbody id="summary-body"></tbody>
+            <tfoot>
+              <tr>
+                <td colspan="2">Subtotal</td>
+                <td id="summary-subtotal">—</td>
+              </tr>
+              <tr>
+                <td colspan="2">Descuento</td>
+                <td id="summary-discount">—</td>
+              </tr>
+              <tr>
+                <td colspan="2">Total</td>
+                <td id="summary-total">—</td>
+              </tr>
+            </tfoot>
+          </table>
+          <div class="checkout__success" hidden>
+            <h3>¡Pedido confirmado!</h3>
+            <p id="order-number"></p>
+            <button class="btn btn--outline" type="button" id="print-order">Imprimir / Guardar PDF</button>
+          </div>
+        </aside>
+      </div>
+    </section>
+
+    <section class="contacto" id="contacto" aria-labelledby="contacto-title">
+      <div class="section-header">
+        <h2 id="contacto-title">Contáctanos</h2>
+        <p>Estamos listos para asesorarte en tu próxima compra.</p>
+      </div>
+      <div class="contacto__layout">
+        <form class="contacto__form">
+          <div class="form-group">
+            <label for="contacto-nombre">Nombre</label>
+            <input id="contacto-nombre" type="text" placeholder="Tu nombre">
+          </div>
+          <div class="form-group">
+            <label for="contacto-email">Email</label>
+            <input id="contacto-email" type="email" placeholder="tu@email.com">
+          </div>
+          <div class="form-group">
+            <label for="contacto-mensaje">Mensaje</label>
+            <textarea id="contacto-mensaje" rows="4" placeholder="¿Cómo podemos ayudarte?"></textarea>
+          </div>
+          <button class="btn btn--outline" type="button">Enviar consulta</button>
+        </form>
+        <div class="contacto__info">
+          <p><strong>Teléfono:</strong> <a data-phone href="tel:+593999999999">+593 99 999 9999</a></p>
+          <p><strong>Email:</strong> <a data-email href="mailto:ventas@jfjoyas.com">ventas@jfjoyas.com</a></p>
+          <p><strong>Horario:</strong> Lunes a sábado de 10h00 a 19h00.</p>
+        </div>
+      </div>
+    </section>
+  </main>
+
+  <footer class="footer">
+    <div class="footer__inner">
+      <p>© <span id="year"></span> JF Joyas. Todos los derechos reservados.</p>
+      <nav aria-label="Legal">
+        <a href="#">Política de privacidad</a>
+        <a href="#">Términos y condiciones</a>
+      </nav>
+      <div class="footer__social">
+        <a href="https://www.instagram.com" target="_blank" rel="noreferrer">Instagram</a>
+        <a href="https://www.facebook.com" target="_blank" rel="noreferrer">Facebook</a>
+      </div>
+    </div>
+  </footer>
+
+  <div class="modal" id="product-modal" role="dialog" aria-modal="true" aria-labelledby="product-modal-title" hidden>
+    <div class="modal__overlay" data-close-modal></div>
+    <div class="modal__content" role="document">
+      <button class="modal__close" type="button" aria-label="Cerrar" data-close-modal>&times;</button>
+      <div class="modal__gallery">
+        <button class="modal__nav" type="button" data-gallery-prev aria-label="Imagen anterior">‹</button>
+        <img id="modal-image" src="" alt="Detalle de producto" width="600" height="600" loading="lazy">
+        <button class="modal__nav" type="button" data-gallery-next aria-label="Imagen siguiente">›</button>
+      </div>
+      <div class="modal__details">
+        <h3 id="product-modal-title"></h3>
+        <p id="modal-description"></p>
+        <ul class="modal__specs">
+          <li><strong>Material:</strong> <span id="modal-material"></span></li>
+          <li><strong>Talla:</strong> <span id="modal-size"></span></li>
+          <li><strong>Peso:</strong> <span id="modal-weight"></span></li>
+          <li><strong>Stock:</strong> <span id="modal-stock"></span></li>
+        </ul>
+        <div class="modal__price" id="modal-price"></div>
+        <div class="quantity-selector">
+          <button type="button" data-qty-decrease aria-label="Disminuir cantidad">−</button>
+          <input type="number" id="modal-quantity" min="1" max="99" value="1" inputmode="numeric" aria-label="Cantidad">
+          <button type="button" data-qty-increase aria-label="Incrementar cantidad">+</button>
+        </div>
+        <button class="btn btn--primary" id="modal-add" type="button">Agregar al carrito</button>
+      </div>
+    </div>
+  </div>
+
+  <aside class="cart" id="cart-panel" aria-labelledby="cart-title" hidden>
+    <div class="cart__overlay" data-close-cart></div>
+    <div class="cart__content" role="dialog" aria-modal="true">
+      <header class="cart__header">
+        <h2 id="cart-title">Tu carrito</h2>
+        <button class="cart__close" type="button" aria-label="Cerrar carrito" data-close-cart>&times;</button>
+      </header>
+      <div class="cart__body" id="cart-items" aria-live="polite"></div>
+      <footer class="cart__footer">
+        <div class="cart__summary">
+          <div><span>Subtotal:</span> <span id="cart-subtotal">—</span></div>
+          <div><span>Descuento:</span> <span id="cart-discount">—</span></div>
+          <div class="cart__total"><span>Total:</span> <span id="cart-total">—</span></div>
+        </div>
+        <button class="btn btn--primary" type="button" id="go-checkout">Ir a Checkout</button>
+      </footer>
+    </div>
+  </aside>
+
+  <a class="whatsapp" id="whatsapp" href="https://wa.me/593999999999?text=Hola%20JF%20Joyas,%20quiero%20más%20información" target="_blank" rel="noreferrer" aria-label="Escríbenos por WhatsApp">
+    <span>WhatsApp</span>
+  </a>
+
+  <script src="assets/js/data.js"></script>
+  <script src="assets/js/app.js"></script>
+</body>
 </html>


### PR DESCRIPTION
## Summary
- build a static single-page "JF Joyas" storefront with hero, catalog, testimonials, FAQ, checkout, and contact sections
- add responsive luxury-inspired styling with gold-on-black theme, focus trapping, and print-optimized checkout summary
- implement data-driven product catalog, modal gallery, validated cart with localStorage persistence, and checkout confirmation flow

## Testing
- python -m http.server 8000

------
https://chatgpt.com/codex/tasks/task_e_68d6e532b8f88330b54ff49f9389efac