### PR TITLE
Update header with VP logo lockup

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -80,6 +80,42 @@ a:focus-visible {
   justify-content: space-between;
 }
 
+.header__logo {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.75rem;
+  color: var(--text);
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.header__logo:focus-visible {
+  outline: 2px solid var(--gold);
+  outline-offset: 4px;
+}
+
+.header__logo-circle {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 44px;
+  height: 44px;
+  border-radius: 50%;
+  background: var(--gold);
+  color: var(--bg);
+  font-size: 1rem;
+  font-weight: 700;
+}
+
+.header__logo-text {
+  font-size: 1.05rem;
+  font-weight: 600;
+  color: var(--text);
+  text-transform: none;
+  letter-spacing: normal;
+}
+
 .header__nav {
   position: relative;
 }

--- a/index.html
+++ b/index.html
@@ -19,8 +19,9 @@
   <a class="skip-link" href="#catalogo">Saltar al catálogo</a>
   <header class="header" id="inicio">
     <div class="header__inner">
-      <a href="#inicio" class="header__logo" aria-label="Inicio JF Joyas">
-        <img src="assets/img/logo.svg" alt="JF Joyas" width="120" height="32">
+      <a href="#inicio" class="header__logo" aria-label="Inicio Valeska Ponce">
+        <span class="header__logo-circle" aria-hidden="true">VP</span>
+        <span class="header__logo-text">Valeska Ponce</span>
       </a>
       <nav class="header__nav" aria-label="Principal">
         <button class="header__toggle" aria-expanded="false" aria-controls="menu">☰</button>


### PR DESCRIPTION
## Summary
- replace the header logo markup with a VP circular monogram and brand name link
- add CSS styling to present the monogram circle and align the lockup with the navigation

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d6e9952e2883309a198223f1ab5fda