### PR TITLE
Switch product data loading to global scripts

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,12 +1,8 @@
-import { productos } from "./data.js";
-
-const $grid = document.getElementById("grid-productos");
-const $year = document.getElementById("year");
-
 const fmtUSD = new Intl.NumberFormat("es-EC", { style: "currency", currency: "USD" });
+const placeholderImg = "https://via.placeholder.com/400x400?text=Sin+imagen";
 
 function cardHTML(p) {
-  const img = (p.imagenes && p.imagenes[0]) || "";
+  const img = (Array.isArray(p.imagenes) && p.imagenes[0]) || placeholderImg;
   return `
   <article class="card" data-id="${p.id}">
     <img class="card__img" src="${img}" alt="${p.nombre}">
@@ -23,13 +19,28 @@ function cardHTML(p) {
   </article>`;
 }
 
-function render() {
-  if (!$grid) return;
-  $grid.innerHTML = productos.map(cardHTML).join("");
-}
-
 document.addEventListener("DOMContentLoaded", () => {
-  render();
+  try {
+    const data = window.productos;
+    console.log("Productos cargados", data);
+
+    if (!Array.isArray(data)) {
+      console.error("La fuente de datos de productos no es un arreglo válido.", data);
+      return;
+    }
+
+    const $grid = document.getElementById("grid-productos");
+    if (!$grid) {
+      console.error("No se encontró el contenedor del catálogo.");
+      return;
+    }
+
+    $grid.innerHTML = data.map(cardHTML).join("");
+  } catch (error) {
+    console.error("Error al inicializar la aplicación:", error);
+  }
+
+  const $year = document.getElementById("year");
   if ($year) {
     $year.textContent = new Date().getFullYear();
   }

--- a/data.js
+++ b/data.js
@@ -93,4 +93,4 @@ const productos = [
   }
 ];
 
-export { productos };
+window.productos = productos;

--- a/index.html
+++ b/index.html
@@ -139,6 +139,7 @@
     </div>
   </footer>
 
-  <script type="module" src="./app.js"></script>
+  <script src="./data.js"></script>
+  <script src="./app.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- load data.js before app.js in index.html to remove module usage
- expose the productos array as a global and update app.js to consume it safely
- add defensive rendering with placeholder images and error handling during initialization

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d7219c9d948330bb7c84cf0114059f