### PR TITLE
Add static ValeskaPonce site with relative asset routing

### DIFF
--- a/public_html/ValeskaPonce/assets/hero.svg
+++ b/public_html/ValeskaPonce/assets/hero.svg
@@ -1,0 +1,16 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1440 720" preserveAspectRatio="xMidYMid slice">
+  <defs>
+    <linearGradient id="bgGrad" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#0f172a" />
+      <stop offset="50%" stop-color="#1d4ed8" />
+      <stop offset="100%" stop-color="#38bdf8" />
+    </linearGradient>
+    <radialGradient id="glow" cx="0.7" cy="0.3" r="0.6">
+      <stop offset="0%" stop-color="#e0f2fe" stop-opacity="0.6" />
+      <stop offset="100%" stop-color="#e0f2fe" stop-opacity="0" />
+    </radialGradient>
+  </defs>
+  <rect width="1440" height="720" fill="url(#bgGrad)" />
+  <circle cx="1080" cy="216" r="360" fill="url(#glow)" />
+  <circle cx="420" cy="540" r="280" fill="url(#glow)" opacity="0.5" />
+</svg>

--- a/public_html/ValeskaPonce/assets/logo.svg
+++ b/public_html/ValeskaPonce/assets/logo.svg
@@ -1,0 +1,12 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 120 120" role="img" aria-labelledby="title desc">
+  <title id="title">Valeska Ponce Logo</title>
+  <desc id="desc">Stylized initials VP inside a circle</desc>
+  <defs>
+    <linearGradient id="grad" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#38bdf8" />
+      <stop offset="100%" stop-color="#6366f1" />
+    </linearGradient>
+  </defs>
+  <circle cx="60" cy="60" r="56" fill="url(#grad)" />
+  <path d="M38 82L50 38h14l12 44h-11l-2.2-10H50.7L48.5 82H38zm21-22h11.4L61 48.6 59 60z" fill="#0f172a" />
+</svg>

--- a/public_html/ValeskaPonce/components/ContactSection.js
+++ b/public_html/ValeskaPonce/components/ContactSection.js
@@ -1,0 +1,69 @@
+export default function createContactSection() {
+  const section = document.createElement("section");
+  section.id = "contacto";
+  section.className = "section section--highlight";
+
+  const container = document.createElement("div");
+  container.className = "section__inner";
+
+  const heading = document.createElement("h2");
+  heading.textContent = "Construyamos tu próximo lanzamiento";
+
+  const description = document.createElement("p");
+  description.className = "section__intro";
+  description.textContent = "En 48 horas coordinamos una llamada exploratoria para definir alcance, entregables y tiempos.";
+
+  const form = document.createElement("form");
+  form.className = "contact-form";
+  form.action = "https://formspree.io/f/mayvlkqr";
+  form.method = "post";
+
+  form.append(
+    createField({ label: "Nombre", name: "name", type: "text", autocomplete: "name" }),
+    createField({ label: "Correo", name: "email", type: "email", autocomplete: "email" }),
+    createTextArea({
+      label: "Cuéntanos sobre tu proyecto",
+      name: "message",
+      rows: 4
+    })
+  );
+
+  const submit = document.createElement("button");
+  submit.type = "submit";
+  submit.className = "button button--primary";
+  submit.textContent = "Agendar conversación";
+
+  form.append(submit);
+  container.append(heading, description, form);
+  section.append(container);
+  return section;
+}
+
+function createField({ label, name, type, autocomplete }) {
+  const wrapper = document.createElement("label");
+  wrapper.className = "field";
+  wrapper.textContent = label;
+
+  const input = document.createElement("input");
+  input.type = type;
+  input.name = name;
+  input.autocomplete = autocomplete;
+  input.required = true;
+
+  wrapper.append(input);
+  return wrapper;
+}
+
+function createTextArea({ label, name, rows }) {
+  const wrapper = document.createElement("label");
+  wrapper.className = "field";
+  wrapper.textContent = label;
+
+  const textarea = document.createElement("textarea");
+  textarea.name = name;
+  textarea.rows = rows;
+  textarea.required = true;
+
+  wrapper.append(textarea);
+  return wrapper;
+}

--- a/public_html/ValeskaPonce/components/Footer.js
+++ b/public_html/ValeskaPonce/components/Footer.js
@@ -1,0 +1,18 @@
+export default function createFooter() {
+  const footer = document.createElement("footer");
+  footer.className = "site-footer";
+
+  const container = document.createElement("div");
+  container.className = "site-footer__inner";
+
+  const copy = document.createElement("p");
+  copy.textContent = `© ${new Date().getFullYear()} Valeska Ponce Studio. Todos los derechos reservados.`;
+
+  const smallPrint = document.createElement("p");
+  smallPrint.className = "site-footer__note";
+  smallPrint.textContent = "Este sitio estático usa únicamente rutas relativas, listo para desplegarse en cualquier carpeta.";
+
+  container.append(copy, smallPrint);
+  footer.append(container);
+  return footer;
+}

--- a/public_html/ValeskaPonce/components/Header.js
+++ b/public_html/ValeskaPonce/components/Header.js
@@ -1,0 +1,45 @@
+export default function createHeader() {
+  const header = document.createElement("header");
+  header.className = "site-header";
+
+  const logoLink = document.createElement("a");
+  logoLink.href = "#inicio";
+  logoLink.className = "logo";
+
+  const logoImg = document.createElement("img");
+  logoImg.src = "./assets/logo.svg";
+  logoImg.alt = "Logotipo de Valeska Ponce";
+  logoImg.width = 64;
+  logoImg.height = 64;
+  logoLink.append(logoImg, createSpan("Valeska Ponce"));
+
+  const nav = document.createElement("nav");
+  nav.setAttribute("aria-label", "Navegación principal");
+
+  const sections = [
+    { href: "#servicios", label: "Servicios" },
+    { href: "#metodologia", label: "Metodología" },
+    { href: "#equipo", label: "Equipo" },
+    { href: "#contacto", label: "Contacto" }
+  ];
+
+  const list = document.createElement("ul");
+  sections.forEach((section) => {
+    const item = document.createElement("li");
+    const link = document.createElement("a");
+    link.href = section.href;
+    link.textContent = section.label;
+    item.append(link);
+    list.append(item);
+  });
+
+  nav.append(list);
+  header.append(logoLink, nav);
+  return header;
+}
+
+function createSpan(text) {
+  const span = document.createElement("span");
+  span.textContent = text;
+  return span;
+}

--- a/public_html/ValeskaPonce/components/HeroSection.js
+++ b/public_html/ValeskaPonce/components/HeroSection.js
@@ -1,0 +1,37 @@
+export default function createHeroSection() {
+  const section = document.createElement("section");
+  section.id = "inicio";
+  section.className = "hero";
+
+  const container = document.createElement("div");
+  container.className = "hero__content";
+
+  const badge = document.createElement("p");
+  badge.className = "hero__badge";
+  badge.textContent = "Estudio creativo + estrategia digital";
+
+  const title = document.createElement("h1");
+  title.textContent = "Diseñamos experiencias memorables que convierten";
+
+  const description = document.createElement("p");
+  description.className = "hero__description";
+  description.textContent = "Unimos investigación, branding y desarrollo front-end para lanzar sitios estáticos listos para brillar en cualquier dominio.";
+
+  const ctaList = document.createElement("div");
+  ctaList.className = "hero__actions";
+
+  const primary = document.createElement("a");
+  primary.className = "button button--primary";
+  primary.href = "#contacto";
+  primary.textContent = "Hablemos de tu proyecto";
+
+  const secondary = document.createElement("a");
+  secondary.className = "button button--ghost";
+  secondary.href = "#servicios";
+  secondary.textContent = "Ver servicios";
+
+  ctaList.append(primary, secondary);
+  container.append(badge, title, description, ctaList);
+  section.append(container);
+  return section;
+}

--- a/public_html/ValeskaPonce/components/MethodologySection.js
+++ b/public_html/ValeskaPonce/components/MethodologySection.js
@@ -1,0 +1,51 @@
+const STEPS = [
+  {
+    title: "Descubrimiento",
+    description: "Investigamos contexto, métricas y audiencia. Cerramos objetivos compartidos y criterios de éxito." 
+  },
+  {
+    title: "Prototipado",
+    description: "Creamos prototipos navegables y guías de contenido para validar decisiones antes del desarrollo." 
+  },
+  {
+    title: "Entrega",
+    description: "Implementamos un sitio estático accesible con rutas 100% relativas, optimizado para cualquier carpeta." 
+  }
+];
+
+export default function createMethodologySection() {
+  const section = document.createElement("section");
+  section.id = "metodologia";
+  section.className = "section section--muted";
+
+  const container = document.createElement("div");
+  container.className = "section__inner";
+
+  const heading = document.createElement("h2");
+  heading.textContent = "Cómo trabajamos";
+
+  const list = document.createElement("ol");
+  list.className = "step-list";
+
+  STEPS.forEach((step, index) => {
+    const item = document.createElement("li");
+    item.className = "step";
+
+    const number = document.createElement("span");
+    number.className = "step__number";
+    number.textContent = `0${index + 1}`;
+
+    const title = document.createElement("h3");
+    title.textContent = step.title;
+
+    const description = document.createElement("p");
+    description.textContent = step.description;
+
+    item.append(number, title, description);
+    list.append(item);
+  });
+
+  container.append(heading, list);
+  section.append(container);
+  return section;
+}

--- a/public_html/ValeskaPonce/components/ProductGrid.js
+++ b/public_html/ValeskaPonce/components/ProductGrid.js
@@ -1,0 +1,41 @@
+export default function createProductGrid(products) {
+  const section = document.createElement("section");
+  section.id = "servicios";
+  section.className = "section section--light";
+
+  const container = document.createElement("div");
+  container.className = "section__inner";
+
+  const heading = document.createElement("h2");
+  heading.textContent = "Servicios en los que brillamos";
+
+  const intro = document.createElement("p");
+  intro.className = "section__intro";
+  intro.textContent = "Cada colaboración comienza con investigación profunda y termina con entregables claros, documentados y fáciles de mantener.";
+
+  const grid = document.createElement("div");
+  grid.className = "card-grid";
+
+  products.forEach((product) => {
+    const card = document.createElement("article");
+    card.className = "card";
+    card.setAttribute("data-id", product.id);
+
+    const title = document.createElement("h3");
+    title.textContent = product.title;
+
+    const description = document.createElement("p");
+    description.textContent = product.description;
+
+    const price = document.createElement("p");
+    price.className = "card__price";
+    price.textContent = product.price;
+
+    card.append(title, description, price);
+    grid.append(card);
+  });
+
+  container.append(heading, intro, grid);
+  section.append(container);
+  return section;
+}

--- a/public_html/ValeskaPonce/components/TeamSection.js
+++ b/public_html/ValeskaPonce/components/TeamSection.js
@@ -1,0 +1,40 @@
+export default function createTeamSection(teamMembers) {
+  const section = document.createElement("section");
+  section.id = "equipo";
+  section.className = "section";
+
+  const container = document.createElement("div");
+  container.className = "section__inner";
+
+  const heading = document.createElement("h2");
+  heading.textContent = "Personas detrás del estudio";
+
+  const intro = document.createElement("p");
+  intro.className = "section__intro";
+  intro.textContent = "Somos un equipo compacto y coordinado. Trabajamos en sprints cortos y medimos cada entrega.";
+
+  const grid = document.createElement("div");
+  grid.className = "team-grid";
+
+  teamMembers.forEach((member) => {
+    const card = document.createElement("article");
+    card.className = "team-card";
+
+    const name = document.createElement("h3");
+    name.textContent = member.name;
+
+    const role = document.createElement("p");
+    role.className = "team-card__role";
+    role.textContent = member.role;
+
+    const bio = document.createElement("p");
+    bio.textContent = member.bio;
+
+    card.append(name, role, bio);
+    grid.append(card);
+  });
+
+  container.append(heading, intro, grid);
+  section.append(container);
+  return section;
+}

--- a/public_html/ValeskaPonce/data/products.json
+++ b/public_html/ValeskaPonce/data/products.json
@@ -1,0 +1,20 @@
+[
+  {
+    "id": "ux-audit",
+    "title": "Auditoría UX Integral",
+    "description": "Evaluamos la experiencia de usuario de tu producto para detectar oportunidades claras de mejora.",
+    "price": "Desde $500"
+  },
+  {
+    "id": "brand-sprint",
+    "title": "Brand Strategy Sprint",
+    "description": "Definimos mensajes, tono y visuales para impulsar una identidad memorable y coherente.",
+    "price": "Desde $750"
+  },
+  {
+    "id": "web-refresh",
+    "title": "Web Refresh Express",
+    "description": "Rediseñamos tu sitio estático con foco en performance, accesibilidad y contenido estratégico.",
+    "price": "Desde $980"
+  }
+]

--- a/public_html/ValeskaPonce/data/team.json
+++ b/public_html/ValeskaPonce/data/team.json
@@ -1,0 +1,17 @@
+[
+  {
+    "name": "Valeska Ponce",
+    "role": "Directora Creativa",
+    "bio": "Diseñadora multidisciplinaria con 10+ años liderando experiencias digitales centradas en las personas."
+  },
+  {
+    "name": "Leonel Rivera",
+    "role": "Estratega de Contenido",
+    "bio": "Traductor entre negocio y audiencia: convierte investigación en narrativas memorables."
+  },
+  {
+    "name": "María Quispe",
+    "role": "Desarrolladora Front-end",
+    "bio": "Especialista en sitios estáticos ultra rápidos, accesibles y fáciles de mantener."
+  }
+]

--- a/public_html/ValeskaPonce/index.css
+++ b/public_html/ValeskaPonce/index.css
@@ -1,0 +1,361 @@
+:root {
+  color-scheme: light dark;
+  --color-bg: #0f172a;
+  --color-bg-muted: #111c34;
+  --color-surface: #f8fafc;
+  --color-text: #0b1220;
+  --color-text-muted: #475569;
+  --color-primary: #2563eb;
+  --color-primary-soft: #38bdf8;
+  --max-width: 1100px;
+  font-family: "Inter", "Segoe UI", system-ui, -apple-system, BlinkMacSystemFont, sans-serif;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  background-color: var(--color-bg);
+  color: var(--color-surface);
+  font-size: 16px;
+  line-height: 1.6;
+}
+
+#app {
+  display: flex;
+  flex-direction: column;
+  min-height: 100vh;
+}
+
+main {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+}
+
+a {
+  color: inherit;
+  text-decoration: none;
+}
+
+a:hover,
+a:focus {
+  text-decoration: underline;
+}
+
+.skip-link {
+  position: absolute;
+  left: -999px;
+  top: auto;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+}
+
+.skip-link:focus {
+  left: 1rem;
+  top: 1rem;
+  width: auto;
+  height: auto;
+  padding: 0.75rem 1rem;
+  background: var(--color-surface);
+  color: var(--color-text);
+  border-radius: 999px;
+  box-shadow: 0 10px 30px rgba(15, 23, 42, 0.2);
+}
+
+.site-header {
+  position: sticky;
+  top: 0;
+  z-index: 10;
+  backdrop-filter: blur(12px);
+  background: rgba(15, 23, 42, 0.75);
+  border-bottom: 1px solid rgba(148, 163, 184, 0.2);
+}
+
+.site-header .logo {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.75rem;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+}
+
+.site-header img {
+  display: block;
+}
+
+.site-header nav ul {
+  display: flex;
+  list-style: none;
+  gap: 1rem;
+  margin: 0;
+  padding: 0;
+}
+
+.site-header nav a {
+  padding: 0.75rem 0.5rem;
+  font-weight: 500;
+  transition: opacity 0.2s ease;
+  opacity: 0.8;
+}
+
+.site-header nav a:hover,
+.site-header nav a:focus {
+  opacity: 1;
+}
+
+.site-header,
+.section__inner,
+.site-footer__inner {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin: 0 auto;
+  padding: 1.2rem 2rem;
+  max-width: var(--max-width);
+}
+
+.hero {
+  min-height: 90vh;
+  background-image: url("./assets/hero.svg");
+  background-size: cover;
+  background-position: center;
+  display: grid;
+  place-items: center;
+  text-align: left;
+  padding: 4rem 1.5rem 6rem;
+}
+
+.hero__content {
+  max-width: 720px;
+}
+
+.hero__badge {
+  display: inline-block;
+  padding: 0.4rem 1rem;
+  border-radius: 999px;
+  background: rgba(148, 163, 184, 0.15);
+  color: var(--color-primary-soft);
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.hero h1 {
+  font-size: clamp(2.8rem, 5vw, 4rem);
+  margin-bottom: 1rem;
+}
+
+.hero__description {
+  color: rgba(226, 232, 240, 0.85);
+  font-size: 1.1rem;
+  margin-bottom: 2rem;
+}
+
+.hero__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+}
+
+.button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.85rem 1.5rem;
+  border-radius: 999px;
+  font-weight: 600;
+  border: 1px solid transparent;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.button--primary {
+  background: var(--color-primary);
+  color: white;
+  box-shadow: 0 20px 40px rgba(37, 99, 235, 0.35);
+}
+
+.button--primary:hover,
+.button--primary:focus {
+  transform: translateY(-1px);
+}
+
+.button--ghost {
+  border-color: rgba(226, 232, 240, 0.4);
+  color: var(--color-surface);
+}
+
+.section {
+  background: white;
+  color: var(--color-text);
+}
+
+.section--light {
+  background: #f1f5f9;
+}
+
+.section--muted {
+  background: #e2e8f0;
+}
+
+.section--highlight {
+  background: #c7d2fe;
+}
+
+.section__inner {
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 1.5rem;
+  padding: 4rem 2rem;
+}
+
+.section__intro {
+  margin: 0;
+  font-size: 1.05rem;
+  color: var(--color-text-muted);
+  max-width: 680px;
+}
+
+.card-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1.5rem;
+  width: 100%;
+}
+
+.card {
+  background: white;
+  border-radius: 1rem;
+  padding: 1.75rem;
+  box-shadow: 0 20px 45px rgba(15, 23, 42, 0.1);
+  display: grid;
+  gap: 0.75rem;
+  border: 1px solid rgba(148, 163, 184, 0.2);
+}
+
+.card__price {
+  font-weight: 700;
+  color: var(--color-primary);
+}
+
+.team-grid {
+  width: 100%;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 1.5rem;
+}
+
+.team-card {
+  background: white;
+  border-radius: 1rem;
+  padding: 1.5rem;
+  border: 1px solid rgba(148, 163, 184, 0.3);
+  box-shadow: 0 10px 30px rgba(15, 23, 42, 0.08);
+}
+
+.team-card__role {
+  margin-top: -0.3rem;
+  font-weight: 600;
+  color: var(--color-primary);
+}
+
+.step-list {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 1.5rem;
+  width: 100%;
+  counter-reset: steps;
+}
+
+.step {
+  background: rgba(255, 255, 255, 0.9);
+  border-radius: 1rem;
+  padding: 1.5rem;
+  border: 1px solid rgba(148, 163, 184, 0.4);
+  box-shadow: 0 12px 28px rgba(15, 23, 42, 0.12);
+}
+
+.step__number {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 0.9rem;
+  font-weight: 700;
+  background: rgba(37, 99, 235, 0.12);
+  color: var(--color-primary);
+  border-radius: 999px;
+  padding: 0.35rem 0.8rem;
+  margin-bottom: 0.5rem;
+}
+
+.contact-form {
+  display: grid;
+  gap: 1rem;
+  width: min(520px, 100%);
+}
+
+.field {
+  display: grid;
+  gap: 0.5rem;
+  font-weight: 600;
+}
+
+.field input,
+.field textarea {
+  padding: 0.85rem 1rem;
+  border-radius: 0.75rem;
+  border: 1px solid rgba(15, 23, 42, 0.15);
+  font: inherit;
+}
+
+.field input:focus,
+.field textarea:focus {
+  border-color: var(--color-primary);
+  outline: none;
+  box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.2);
+}
+
+.site-footer {
+  background: #0b1120;
+  color: rgba(226, 232, 240, 0.8);
+}
+
+.site-footer__inner {
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 0.5rem;
+  padding-top: 2rem;
+  padding-bottom: 2rem;
+}
+
+.site-footer__note {
+  margin: 0;
+  font-size: 0.9rem;
+  color: rgba(148, 163, 184, 0.9);
+}
+
+@media (max-width: 720px) {
+  .site-header,
+  .section__inner,
+  .site-footer__inner {
+    padding: 1rem 1.5rem;
+  }
+
+  .site-header {
+    flex-direction: column;
+    gap: 0.5rem;
+  }
+
+  .site-header nav ul {
+    flex-wrap: wrap;
+    justify-content: center;
+  }
+
+  .hero {
+    padding-top: 6rem;
+    padding-bottom: 6rem;
+  }
+}

--- a/public_html/ValeskaPonce/index.html
+++ b/public_html/ValeskaPonce/index.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="es">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Valeska Ponce Studio · Diseño estratégico y sitios estáticos</title>
+    <meta name="description" content="Estudio creativo que diseña experiencias digitales memorables con rutas 100% relativas.">
+    <base href="./">
+    <link rel="stylesheet" href="./index.css">
+  </head>
+  <body>
+    <a class="skip-link" href="#inicio">Saltar al contenido</a>
+    <div id="app"></div>
+    <script type="module" src="./index.js" defer></script>
+  </body>
+</html>

--- a/public_html/ValeskaPonce/index.js
+++ b/public_html/ValeskaPonce/index.js
@@ -1,0 +1,99 @@
+import createHeader from "./components/Header.js";
+import createHeroSection from "./components/HeroSection.js";
+import createProductGrid from "./components/ProductGrid.js";
+import createMethodologySection from "./components/MethodologySection.js";
+import createTeamSection from "./components/TeamSection.js";
+import createContactSection from "./components/ContactSection.js";
+import createFooter from "./components/Footer.js";
+
+const IMPORT_PATHS = [
+  "./components/Header.js",
+  "./components/HeroSection.js",
+  "./components/ProductGrid.js",
+  "./components/MethodologySection.js",
+  "./components/TeamSection.js",
+  "./components/ContactSection.js",
+  "./components/Footer.js"
+];
+
+// Validación obligatoria: todas las rutas de import deben iniciar con ./ o ../
+if (IMPORT_PATHS.some((path) => !path.startsWith("./") && !path.startsWith("../"))) {
+  throw new Error("Todas las importaciones internas deben ser rutas relativas.");
+}
+
+async function init() {
+  const root = document.getElementById("app");
+  root.innerHTML = "";
+
+  const header = createHeader();
+  const hero = createHeroSection();
+  const methodology = createMethodologySection();
+  const footer = createFooter();
+
+  const main = document.createElement("main");
+  main.id = "contenido-principal";
+
+  main.append(hero);
+
+  const products = await fetchData("./data/products.json");
+  main.append(createProductGrid(products));
+
+  main.append(methodology);
+
+  const team = await fetchData("./data/team.json");
+  main.append(createTeamSection(team));
+
+  main.append(createContactSection());
+
+  root.append(header, main, footer);
+
+  enforceRelativeResourcePaths();
+}
+
+async function fetchData(path) {
+  const response = await fetch(path);
+  if (!response.ok) {
+    throw new Error(`No se pudo cargar ${path}`);
+  }
+  return response.json();
+}
+
+// Validación obligatoria: no permitir rutas internas que comiencen con / o http(s)://
+function enforceRelativeResourcePaths() {
+  const elements = document.querySelectorAll("[src], [href], [action]");
+  elements.forEach((el) => {
+    ["src", "href", "action"].forEach((attr) => {
+      if (!el.hasAttribute(attr)) {
+        return;
+      }
+      const value = el.getAttribute(attr);
+      if (!value) {
+        return;
+      }
+      if (value.startsWith("#") || value.startsWith("mailto:")) {
+        return;
+      }
+
+      const isAbsolute = value.startsWith("/") || value.startsWith("http://") || value.startsWith("https://");
+      if (!isAbsolute) {
+        return;
+      }
+
+      if (value.startsWith("http://") || value.startsWith("https://")) {
+        try {
+          const url = new URL(value);
+          if (url.origin === window.location.origin) {
+            throw new Error(`Ruta absoluta interna no permitida en ${attr}: ${value}`);
+          }
+          return; // Es un recurso externo, se permite
+        } catch (error) {
+          throw new Error(`URL inválida detectada en ${attr}: ${value}`);
+        }
+      }
+
+      throw new Error(`Ruta relativa requerida en ${attr}, se encontró: ${value}`);
+    });
+  });
+}
+
+document.addEventListener("DOMContentLoaded", init);


### PR DESCRIPTION
## Summary
- add a complete static site structure under `public_html/ValeskaPonce` using only relative paths in HTML, CSS and JS
- break the UI into reusable JavaScript component modules with JSON-driven content
- include runtime checks that enforce relative imports and block internal absolute URLs

## Testing
- python3 -m http.server 8000

------
https://chatgpt.com/codex/tasks/task_e_68d72c9864e08330ba0a1535be39a497